### PR TITLE
Add an examples webhook listener for triggers

### DIFF
--- a/webhook-listener-triggers/README.md
+++ b/webhook-listener-triggers/README.md
@@ -1,0 +1,46 @@
+This is an example webhook listener that will hear notifications coming from triggers and print them to STDOUT.
+
+Here's an example of a notification that Honeycomb Triggers would send and this webhook would accept and print out:
+
+```json
+{
+  "version": "v0.1.0",
+  "shared_secret": "would you like to play a game",
+  "name": "trig on ttt",
+  "status": "TRIGGERED",
+  "summary": "Triggered: trig on ttt",
+  "description": "Currently greater than threshold value (2) for foo:ble (value 5)",
+  "result_url": "",
+  "result_groups": [
+    {
+      "Group": {"foo": "ble"},
+      "Result": 5
+    },
+    {
+      "Group": {"foo": "baz"},
+      "Result": 1
+    },
+    {
+      "Group": {"foo": "bar"},
+      "Result": 1
+    }
+  ],
+  "result_groups_triggered": [
+    {
+      "Group": {"foo": "ble"},
+      "Result": 5
+    }
+  ]
+}
+```
+
+The query that's attached to this trigger is:
+* breakdown on column `foo`
+* alert if `COUNT > 2`
+* notify a webhook at `http://myhost.com/notify` with the shared secret `would you like to play a game`
+
+The notification is in the `TRIGGERED` state, which mean it has just crossed the threshold.
+
+The `result_groups` key lists every value for the `foo` column and the counts ofr each one. In this case, `foo` has 3 values: `ble`, `baz`, and `bar`. `bar` and `baz` each only have a `COUNT` of 1, and `ble` has a cound of 5.
+
+The `result_groups_triggered` key only lists the `ble` value becaues it is the only one that is more than 2, the threshold configured in the trigger.

--- a/webhook-listener-triggers/README.md
+++ b/webhook-listener-triggers/README.md
@@ -62,3 +62,5 @@ Pull dependencies.
 Run app.
 
     $ go run main.go
+
+Now configure Honeycomb to send a notification to the running listener! Within the Integrations section of your Honeycomb team settings, create a Trigger Recipient with the parameters: Provider: `Webhook`, Webhook URL: `http://example.com:8090/notify`. Create a trigger and add this Webhook as a Recipient. When your trigger fires, Honeycomb will notify this Webhook! (Tools like [ngrok](https://ngrok.com/) can help your local process be available via the public web!)

--- a/webhook-listener-triggers/README.md
+++ b/webhook-listener-triggers/README.md
@@ -50,3 +50,15 @@ The notification is in the `TRIGGERED` state, which mean it has just crossed the
 The `result_groups` key lists every value for the `foo` column and the counts ofr each one. In this case, `foo` has 3 values: `fooOOOddd`, `hungry`, and `chompy`. `chompy` and `hungry` each only have a `COUNT` of 1, and `fooOOOddd` has a cound of 5.
 
 The `result_groups_triggered` key only lists the `fooOOOddd` value becaues it is the only one that is more than 2, the threshold configured in the trigger.
+
+## Install
+
+Clone the repository into $GOPATH/src/github.com/honeycombio/examples.
+
+Pull dependencies.
+
+    $ go get -u ./...
+
+Run app.
+
+    $ go run main.go

--- a/webhook-listener-triggers/README.md
+++ b/webhook-listener-triggers/README.md
@@ -1,33 +1,39 @@
-This is an example webhook listener that will hear notifications coming from triggers and print them to STDOUT.
+Honeycomb triggers can specify a webhook as the notification target. When configured in this way, Honeycomb will send an HTTP POST to the URL specified in the trigger configuration. That POST will include:
+
+* A shared secret token for authentication in the `X-Honeycomb-Webhook-Token` header
+* The results of the trigger as JSON in the body.
+
+This is an example webhook listener that will hear notifications coming from triggers and print them to STDOUT. It is intended to show how to receive and parse the notification rather than be used directly - for example configuration is hard coded instead of looking for a config file. It is instrumented with the Honeycomb beeline so you can see what your webhook is doing!
 
 Here's an example of a notification that Honeycomb Triggers would send and this webhook would accept and print out:
 
 ```json
 {
   "version": "v0.1.0",
-  "shared_secret": "would you like to play a game",
   "name": "trig on ttt",
   "status": "TRIGGERED",
   "summary": "Triggered: trig on ttt",
-  "description": "Currently greater than threshold value (2) for foo:ble (value 5)",
+  "description": "Currently greater than threshold value (2) for foo:fooOOOddd (value 5)",
+  "operator": "greater than",
+  "threshold": 2,
   "result_url": "",
   "result_groups": [
     {
-      "Group": {"foo": "ble"},
+      "Group": {"foo": "fooOOOddd"},
       "Result": 5
     },
     {
-      "Group": {"foo": "baz"},
+      "Group": {"foo": "hungry"},
       "Result": 1
     },
     {
-      "Group": {"foo": "bar"},
+      "Group": {"foo": "chompy"},
       "Result": 1
     }
   ],
   "result_groups_triggered": [
     {
-      "Group": {"foo": "ble"},
+      "Group": {"foo": "fooOOOddd"},
       "Result": 5
     }
   ]
@@ -37,10 +43,10 @@ Here's an example of a notification that Honeycomb Triggers would send and this 
 The query that's attached to this trigger is:
 * breakdown on column `foo`
 * alert if `COUNT > 2`
-* notify a webhook at `http://myhost.com/notify` with the shared secret `would you like to play a game`
+* notify a webhook at `http://myhost.com:8090/notify` with the shared secret `would you like to play a game`
 
 The notification is in the `TRIGGERED` state, which mean it has just crossed the threshold.
 
-The `result_groups` key lists every value for the `foo` column and the counts ofr each one. In this case, `foo` has 3 values: `ble`, `baz`, and `bar`. `bar` and `baz` each only have a `COUNT` of 1, and `ble` has a cound of 5.
+The `result_groups` key lists every value for the `foo` column and the counts ofr each one. In this case, `foo` has 3 values: `fooOOOddd`, `hungry`, and `chompy`. `chompy` and `hungry` each only have a `COUNT` of 1, and `fooOOOddd` has a cound of 5.
 
-The `result_groups_triggered` key only lists the `ble` value becaues it is the only one that is more than 2, the threshold configured in the trigger.
+The `result_groups_triggered` key only lists the `fooOOOddd` value becaues it is the only one that is more than 2, the threshold configured in the trigger.

--- a/webhook-listener-triggers/README.md
+++ b/webhook-listener-triggers/README.md
@@ -3,7 +3,7 @@ Honeycomb triggers can specify a webhook as the notification target. When config
 * A shared secret token for authentication in the `X-Honeycomb-Webhook-Token` header
 * The results of the trigger as JSON in the body.
 
-This is an example webhook listener that will hear notifications coming from triggers and print them to STDOUT. It is intended to show how to receive and parse the notification rather than be used directly - for example configuration is hard coded instead of looking for a config file. It is instrumented with the Honeycomb beeline so you can see what your webhook is doing!
+This is an example webhook listener that will hear notifications coming from triggers and print them to STDOUT. It is instrumented with the Honeycomb beeline so you can see what your webhook is doing!
 
 Here's an example of a notification that Honeycomb Triggers would send and this webhook would accept and print out:
 

--- a/webhook-listener-triggers/main.go
+++ b/webhook-listener-triggers/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gorilla/mux"
+	beeline "github.com/honeycombio/beeline-go"
+	"github.com/honeycombio/beeline-go/wrappers/hnygorilla"
+	"github.com/honeycombio/beeline-go/wrappers/hnynethttp"
+)
+
+// Config configures this application
+type Config struct {
+	// SharedSecrets is an authentication key you get from the Triggers UI when
+	// you create a webhook trigger recipient. You should only accept POSTs to
+	// this webhook that have the secret. Secrets are a per-webhook endpoint
+	// config, so if multiple webhook recipients are configured to send to this
+	// app, multiple shared secrets will be necessary.
+	SharedSecres []string
+	// Port is the port on localhost on which this webhook will listen. Default
+	// 8080
+	Port int
+	// Output is the place we'll write the record of receiving notifications
+	// from Honeycomb.  Default STDOUT
+	Output io.Writer
+}
+
+// TriggerResult represents a single row in the table of results that come back
+// from a trigger. A notification will have two lists of TriggerResults, one
+// that is all the rows in the results table and the other that is only the rows
+// that have crossed the threshold specified in the trigger
+type TriggerResult struct {
+	// Groups are the breakdown columns and values in those columns that are
+	// present in the results or have triggered the threshold.
+	Group map[string]interface{}
+	// Result is the value of the Calculation for this group of columns
+	Result float64
+}
+
+// Notification is the message we'll get from the Honeycomb API
+type Notification struct {
+	// Version is the version of this notification - changes to the structure of
+	// this message will trigger changes to this version string
+	Version string `json:"version"`
+	// SharedSecret is configured on a per-webhook basis
+	SharedSecret string `json:"shared_secret"`
+	// TriggerName is the name of this trigger, as configured in the UI
+	TriggerName string `json:"name"`
+	// Status will be TRIGGERED or OK
+	Status          string          `json:"status"`
+	Summary         string          `json:"summary"`
+	Description     string          `json:"description"`
+	Operator        string          `json:"operator"`
+	Threshold       float64         `json:"threshold"`
+	ResultURL       string          `json:"result_url"` // permalink to the trigger results
+	ResultGroups    []TriggerResult `json:"result_groups"`
+	GroupsTriggered []TriggerResult `json:"result_groups_triggered"`
+
+	// Timestamp does not come with the notification but I want it to be
+	// serialized in the output here so we can see when things came in
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type App struct {
+	conf Config
+}
+
+func main() {
+
+	beeline.Init(beeline.Config{
+		WriteKey: "abcabc123123",
+		Dataset:  "http-gorilla",
+		// for demonstration, send the event to STDOUT intead of Honeycomb.
+		// Remove the STDOUT setting when filling in a real write key.
+		// STDOUT: true,
+	})
+
+	var a = &App{}
+	a.conf = getConfig()
+
+	r := mux.NewRouter()
+	r.Use(hnygorilla.Middleware)
+	r.HandleFunc("/notify", a.rcvNotification).Methods("POST")
+	r.HandleFunc("/", a.defaultPath)
+
+	listenAddr := fmt.Sprintf(":%d", a.conf.Port)
+	log.Fatal(http.ListenAndServe(listenAddr, hnynethttp.WrapHandler(r)))
+}
+
+func getConfig() Config {
+	return Config{
+		SharedSecres: []string{"would you like to play a game"},
+		Port:         8090,
+		Output:       os.Stdout,
+	}
+}
+
+func (a *App) defaultPath(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Behold the Kreut in the Forest!\n"))
+}
+
+func (a *App) rcvNotification(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	bod, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("failed to read body\n"))
+		return
+	}
+	fmt.Println(string(bod))
+	var notif = Notification{}
+	err = json.Unmarshal(bod, &notif)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("failed to parse json\n"))
+		return
+	}
+	// now validate that the shared secret is legit
+	var matched bool
+	for _, ss := range a.conf.SharedSecres {
+		if notif.SharedSecret == ss {
+			matched = true
+		}
+	}
+	if !matched {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("failed to authenticate notification\n"))
+		return
+	}
+	// hooray, let's write out our notification
+	notif.Timestamp = time.Now()
+	serialized, err := json.Marshal(notif)
+	a.conf.Output.Write(serialized)
+	a.conf.Output.Write([]byte("\n"))
+	// and respond happily
+	w.Write([]byte("accepted\n"))
+}


### PR DESCRIPTION
This example implements the remote side webhook to listen for trigger notifications. It serves to both illustrate how to consume the notifications as well as document the API.