### PR TITLE
adding rate limiting proxy as another beeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ you along. The current examples are:
 
 | Directory | Meant to Teach | Description |
 | --- | --- | --- |
-| [`golang-gatekeeper`](golang-gatekeeper) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) and custom instrumentation | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/#reference-implementations) |
-| [`ruby-gatekeeper`](ruby-gatekeeper) | [Ruby Beeline](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/) and custom instrumentation | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/#reference-implementations) |
-| [`python-gatekeeper`](python-gatekeeper) | [Python Beeline](https://docs.honeycomb.io/getting-data-in/beelines/python-beeline/) and custom instrumentation | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/#reference-implementations) |
+| [`golang-gatekeeper`](golang-gatekeeper) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | An API server paired with the [Gatekeeper Tour](https://ui.honeycomb.io/quickstart/datasets/gatekeeper-tour) |
+| [`golang-ratelimiting-proxy`](golang-ratelimiting-proxy) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | A rate limiting, tarpitting proxy, intended to be put in front of a web server. |
+| [`ruby-gatekeeper`](ruby-gatekeeper) | [Ruby Beeline](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/) | An API server paired with the [Gatekeeper Tour](https://ui.honeycomb.io/quickstart/datasets/gatekeeper-tour) |
+| [`python-gatekeeper`](python-gatekeeper) | [Python Beeline](https://docs.honeycomb.io/getting-data-in/beelines/python-beeline/) | An API server paired with the [Gatekeeper Tour](https://ui.honeycomb.io/quickstart/datasets/gatekeeper-tour) |
 | [`golang-webapp`](golang-webapp) | [libhoney-go](https://docs.honeycomb.io/sdk/go/) | A two-tier web application (Go+MySQL) which is a Twitter clone. |
 | [`honeytail-dockerd`](honeytail-dockerd) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `keyval` parser to ingest the structured logs of the [Docker]() container engine daemon. |
 | [`honeytail-nginx`](honeytail-nginx) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `nginx` parser to ingest [Nginx]() access logs from an instance acting as a reverse proxy. |

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ you along. The current examples are:
 
 | Directory | Meant to Teach | Description |
 | --- | --- | --- |
-| [`golang-gatekeeper`](golang-gatekeeper) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | An API server paired with the [Gatekeeper Tour](https://ui.honeycomb.io/quickstart/datasets/gatekeeper-tour) |
+| [`golang-gatekeeper`](golang-gatekeeper) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
 | [`golang-ratelimiting-proxy`](golang-ratelimiting-proxy) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | A rate limiting, tarpitting proxy, intended to be put in front of a web server. |
-| [`ruby-gatekeeper`](ruby-gatekeeper) | [Ruby Beeline](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/) | An API server paired with the [Gatekeeper Tour](https://ui.honeycomb.io/quickstart/datasets/gatekeeper-tour) |
-| [`python-gatekeeper`](python-gatekeeper) | [Python Beeline](https://docs.honeycomb.io/getting-data-in/beelines/python-beeline/) | An API server paired with the [Gatekeeper Tour](https://ui.honeycomb.io/quickstart/datasets/gatekeeper-tour) |
+| [`ruby-gatekeeper`](ruby-gatekeeper) | [Ruby Beeline](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/) | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
+| [`python-gatekeeper`](python-gatekeeper) | [Python Beeline](https://docs.honeycomb.io/getting-data-in/beelines/python-beeline/) | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
 | [`golang-webapp`](golang-webapp) | [libhoney-go](https://docs.honeycomb.io/sdk/go/) | A two-tier web application (Go+MySQL) which is a Twitter clone. |
 | [`honeytail-dockerd`](honeytail-dockerd) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `keyval` parser to ingest the structured logs of the [Docker]() container engine daemon. |
 | [`honeytail-nginx`](honeytail-nginx) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `nginx` parser to ingest [Nginx]() access logs from an instance acting as a reverse proxy. |

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ you along. The current examples are:
 
 | Directory | Meant to Teach | Description |
 | --- | --- | --- |
-| [`golang-gatekeeper`](golang-gatekeeper) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
-| [`golang-ratelimiting-proxy`](golang-ratelimiting-proxy) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) | A rate limiting, tarpitting proxy, intended to be put in front of a web server. |
-| [`ruby-gatekeeper`](ruby-gatekeeper) | [Ruby Beeline](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/) | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
-| [`python-gatekeeper`](python-gatekeeper) | [Python Beeline](https://docs.honeycomb.io/getting-data-in/beelines/python-beeline/) | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
+| [`golang-gatekeeper`](golang-gatekeeper) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) and custom instrumentation | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
+| [`golang-ratelimiting-proxy`](golang-ratelimiting-proxy) | [Go Beeline](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) and cross-service tracing | A rate limiting, tarpitting proxy, intended to be put in front of a web server. |
+| [`ruby-gatekeeper`](ruby-gatekeeper) | [Ruby Beeline](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/) and custom instrumentation | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
+| [`python-gatekeeper`](python-gatekeeper) | [Python Beeline](https://docs.honeycomb.io/getting-data-in/beelines/python-beeline/) and custom instrumentation | An API server paired with the [Gatekeeper Tour](https://docs.honeycomb.io/gatekeeper-tour/) |
 | [`golang-webapp`](golang-webapp) | [libhoney-go](https://docs.honeycomb.io/sdk/go/) | A two-tier web application (Go+MySQL) which is a Twitter clone. |
 | [`honeytail-dockerd`](honeytail-dockerd) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `keyval` parser to ingest the structured logs of the [Docker]() container engine daemon. |
 | [`honeytail-nginx`](honeytail-nginx) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `nginx` parser to ingest [Nginx]() access logs from an instance acting as a reverse proxy. |

--- a/golang-ratelimiting-proxy/README.md
+++ b/golang-ratelimiting-proxy/README.md
@@ -1,0 +1,9 @@
+# golang-ratelimiting-proxy
+
+This example contains a simple HTTP proxy which rate limits based on remote IP address before passing the requests on to a localhost webserver.
+
+This is a **fully-instrumented** service using the [Beeline for Go](https://github.com/honeycombio/beeline-go/) that propagates tracing headers through to the downstream application.
+
+## More examples
+
+See our announcement of the [Beeline for Go v2](https://www.honeycomb.io/blog/2018/09/the-honeycomb-beeline-for-go-v2-is-go/) for more information and discussion of how to trace across service boundaries.

--- a/golang-ratelimiting-proxy/main.go
+++ b/golang-ratelimiting-proxy/main.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
+	"math"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	beeline "github.com/honeycombio/beeline-go"
+	"github.com/honeycombio/beeline-go/wrappers/hnynethttp"
+	"github.com/honeycombio/leakybucket"
+)
+
+// rate limiting proxy is a forwarding proxy that has a built in rate limit. In
+// the style of a tarpit, it waits a random amount of time before returning when
+// rate limiting connections. The forwarding target and rate limits are hard
+// coded.  Based on the client IP address, it allows through bursts of up to 50
+// and sustained requests of 8 per second for all GET requests. It allows a
+// burst of 10 and sustained 1/sec for all other HTTP methods (eg POST, PUT,
+// etc.).
+
+const (
+	// downstreamTarget is who this proxy fronts
+	downstreamTarget = "http://localhost:8090"
+
+	// the default limits for GET and all other requests
+	getBurstLimit        = 50
+	getThroughputLimit   = 8
+	otherBurstLimit      = 10
+	otherThroughputLimit = 1
+
+	// how long should we hold on to rate limited request connections (in ms)?
+	waitBaseTime = 100.0
+	waitRange    = 500.0
+	waitStdDev   = 100.0
+)
+
+type app struct {
+	client      *http.Client
+	rateLimiter map[string]*leakybucket.Bucket
+	sync.Mutex
+}
+
+func main() {
+
+	wk := os.Getenv("HONEYCOMB_APIKEY")
+	var useStdout bool
+	if wk == "" {
+		useStdout = true
+	}
+	// Initialize beeline. The only required field is WriteKey.
+	beeline.Init(beeline.Config{
+		WriteKey:    wk,
+		Dataset:     "beeline-example",
+		ServiceName: "rlp",
+		// In no writekey is configured, send the event to STDOUT instead of Honeycomb.
+		STDOUT: useStdout,
+	})
+
+	// create a custom client that has sane timeouts and records outbound events
+	client := &http.Client{
+		Timeout: time.Second * 10,
+		Transport: hnynethttp.WrapRoundTripper(&http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 6 * time.Second,
+		}),
+	}
+
+	a := &app{
+		client:      client,
+		rateLimiter: make(map[string]*leakybucket.Bucket),
+	}
+
+	http.HandleFunc("/", hnynethttp.WrapHandlerFunc(a.proxy))
+	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+}
+
+func (a *app) proxy(w http.ResponseWriter, req *http.Request) {
+	var rateKey string
+	forwarded := req.Header.Get("X-Forwarded-For")
+	beeline.AddField(req.Context(), "forwarded_for_incoming", forwarded)
+	if forwarded == "" {
+		rateKey = strings.Split(req.RemoteAddr, ":")[0]
+	} else {
+		rateKey = forwarded
+	}
+
+	// check rate limits
+	beeline.AddField(req.Context(), "rate_limit_key", rateKey)
+	hitCapacity := a.shouldRateLimit(req.Method, rateKey)
+	if hitCapacity != nil {
+		beeline.AddField(req.Context(), "error", "rate limit exceeded")
+		ctx, span := beeline.StartSpan(req.Context(), "wait")
+		defer span.Send()
+		sleepTime := math.Abs(waitBaseTime + (rand.NormFloat64()*waitStdDev + waitRange))
+		beeline.AddField(ctx, "wait_time", sleepTime)
+		// sleep a random amount in the range (waitBaseTime to waitBaseTime+waitRange)
+		// aka 100-600ms
+		time.Sleep(time.Duration(sleepTime) * time.Millisecond)
+
+		// ok, go ahead and reply
+		w.WriteHeader(http.StatusTooManyRequests)
+		io.WriteString(w, `{"error":"rate limit exceeded; please wait 1sec and try again"}`)
+		return
+	}
+	// ok we're allowed to proceed, let's copy the request over to a new one and
+	// dispatch it downstream
+	defer req.Body.Close()
+	reqBod, _ := ioutil.ReadAll(req.Body)
+	buf := bytes.NewBuffer(reqBod)
+	downstreamReq, err := http.NewRequest(req.Method, downstreamTarget+req.URL.String(), buf)
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		io.WriteString(w, `{"error":"failed to create downstream request"}`)
+		beeline.AddField(req.Context(), "error", err)
+		beeline.AddField(req.Context(), "error_detail", "failed to create downstream request")
+		return
+	}
+	// add context to propagate the beeline trace
+	downstreamReq = downstreamReq.WithContext(req.Context())
+	// copy over headers from upstream to the downstream service
+	for header, vals := range req.Header {
+		downstreamReq.Header.Set(header, strings.Join(vals, ","))
+	}
+	if forwarded != "" {
+		downstreamReq.Header.Set("X-Forwarded-For", forwarded+", "+req.RemoteAddr)
+	} else {
+		downstreamReq.Header.Set("X-Forwarded-For", req.RemoteAddr)
+	}
+	beeline.AddField(req.Context(), "forwarded_for_outgoing", downstreamReq.Header.Get("X-Forwarded-For"))
+	// call the downstream service
+	resp, err := a.client.Do(downstreamReq)
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		io.WriteString(w, `{"error":"downstream target unavailable"}`)
+		beeline.AddField(req.Context(), "error", err)
+		beeline.AddField(req.Context(), "error_detail", "downstream target unavailable")
+		return
+	}
+	// ok, we got a response, let's pass it along
+	defer resp.Body.Close()
+	// copy over headers
+	for header, vals := range resp.Header {
+		w.Header().Set(header, strings.Join(vals, ","))
+	}
+	// copy over status code
+	w.WriteHeader(resp.StatusCode)
+	// copy over body
+	io.Copy(w, resp.Body)
+}
+
+func (a *app) shouldRateLimit(method, key string) error {
+	a.Lock()
+	defer a.Unlock()
+
+	var b *leakybucket.Bucket
+	b, ok := a.rateLimiter[method+key]
+	if !ok {
+		if method == "GET" {
+			b = &leakybucket.Bucket{
+				Capacity:    getBurstLimit,
+				DrainAmount: getThroughputLimit,
+				DrainPeriod: 1 * time.Second,
+			}
+		} else {
+			b = &leakybucket.Bucket{
+				Capacity:    otherBurstLimit,
+				DrainAmount: otherThroughputLimit,
+				DrainPeriod: 1 * time.Second,
+			}
+		}
+		a.rateLimiter[method+key] = b
+	}
+	return b.Add()
+}

--- a/golang-ratelimiting-proxy/ratelimiter.go
+++ b/golang-ratelimiting-proxy/ratelimiter.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"math/rand"
+
+	"github.com/honeycombio/hound/leakybucket"
+)
+
+type RandomRateLimiter struct {
+	Frequency int // how often to reply with rate limited
+}
+
+func (r *RandomRateLimiter) Add(key string, opts leakybucket.Options) error {
+	if rand.Intn(r.Frequency) == 0 {
+		return &leakybucket.BucketOverflow{}
+	}
+	return nil
+}
+func (r *RandomRateLimiter) Start() error {
+	return nil
+}
+func (r *RandomRateLimiter) Stop() error {
+	return nil
+}


### PR DESCRIPTION
This is the rate limiter used in https://www.honeycomb.io/blog/2018/09/the-honeycomb-beeline-for-go-v2-is-go/. It's interesting because it was an actual thing I used for a real need rather than example code written purely for the sake of being an example. It probably needs a README and more explanation about what's going on. 