### PR TITLE
Updated webhook event with triggerID and URL

### DIFF
--- a/webhook-listener-triggers/main.go
+++ b/webhook-listener-triggers/main.go
@@ -53,6 +53,7 @@ type Notification struct {
 	SharedSecret string `json:"shared_secret"`
 	// TriggerName is the name of this trigger, as configured in the UI
 	TriggerName string `json:"name"`
+        TriggerID string   `json:"id"`
 	// Status will be TRIGGERED or OK
 	Status          string          `json:"status"`
 	Summary         string          `json:"summary"`
@@ -62,7 +63,7 @@ type Notification struct {
 	ResultURL       string          `json:"result_url"` // permalink to the trigger results
 	ResultGroups    []TriggerResult `json:"result_groups"`
 	GroupsTriggered []TriggerResult `json:"result_groups_triggered"`
-
+	TriggerURL      string          `json:"trigger_url"`
 	// Timestamp does not come with the notification but I want it to be
 	// serialized in the output here so we can see when things came in
 	Timestamp time.Time `json:"timestamp"`


### PR DESCRIPTION
We now send the trigger ID as well as trigger URL in the webhook payload. Update this code to include those new values. 