### PR TITLE
add java beeline examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ you along. The current examples are:
 | [`honeytail-dockerd`](honeytail-dockerd) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `keyval` parser to ingest the structured logs of the [Docker]() container engine daemon. |
 | [`honeytail-mysql`](honeytail-mysql) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using Honeytail's `mysql` parser to ingest MySQL slow query logs |
 | [`honeytail-nginx`](honeytail-nginx) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `nginx` parser to ingest [Nginx]() access logs from an instance acting as a reverse proxy. |
-| `java-beeline` | A simple web app written instrumented for tracing with the Java Beeline for SpringBoot                           |
+| [`java-beeline`](java-beeline) | [beeline-java](https://docs.honeycomb.io/getting-data-in/java/beeline/)| A simple web app instrumented for tracing with the Java Beeline for SpringBoot |
 | [`java-webapp`](java-webapp) | [libhoney-java](https://docs.honeycomb.io/sdk/java/) | A TODO API written and instrumented using Java Spring |
 | [`kubernetes-envoy-tracing`](kubernetes-envoy-tracing) | Using the [Honeycomb Opentracing Proxy](https://github.com/honeycombio/honeycomb-opentracing-proxy) to accept OpenTracing data | Two small services deployed to Kubernetes which communicate using [Envoy Proxy](https://www.envoyproxy.io/) |
 | [`node-tracing-example`](node-tracing-example) | [Node Beeline](https://docs.honeycomb.io/getting-data-in/javascript/beeline-nodejs/) | A simple webapp showing intra-service and cross-service tracing. |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ you along. The current examples are:
 | [`honeytail-dockerd`](honeytail-dockerd) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `keyval` parser to ingest the structured logs of the [Docker]() container engine daemon. |
 | [`honeytail-mysql`](honeytail-mysql) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using Honeytail's `mysql` parser to ingest MySQL slow query logs |
 | [`honeytail-nginx`](honeytail-nginx) | [Honeytail](https://docs.honeycomb.io/getting-data-in/honeytail/) (flat log files) | Using [Honeytail]()'s `nginx` parser to ingest [Nginx]() access logs from an instance acting as a reverse proxy. |
+| `java-beeline` | A simple web app written instrumented for tracing with the Java Beeline for SpringBoot                           |
 | [`java-webapp`](java-webapp) | [libhoney-java](https://docs.honeycomb.io/sdk/java/) | A TODO API written and instrumented using Java Spring |
 | [`kubernetes-envoy-tracing`](kubernetes-envoy-tracing) | Using the [Honeycomb Opentracing Proxy](https://github.com/honeycombio/honeycomb-opentracing-proxy) to accept OpenTracing data | Two small services deployed to Kubernetes which communicate using [Envoy Proxy](https://www.envoyproxy.io/) |
 | [`node-tracing-example`](node-tracing-example) | [Node Beeline](https://docs.honeycomb.io/getting-data-in/javascript/beeline-nodejs/) | A simple webapp showing intra-service and cross-service tracing. |
@@ -30,18 +31,19 @@ you along. The current examples are:
 | [`ruby-wiki-tracing`](ruby-wiki-tracing) | [Manual Tracing](https://docs.honeycomb.io/working-with-data/tracing/send-trace-data/#manual-tracing) with Ruby | A simple wiki (Ruby) manually instrumented for tracing. |
 | [`webhook-listener-triggers`](webhook-listener-triggers) | Executing a webhook as a result of a [Honeycomb Trigger](https://docs.honeycomb.io/working-with-data/triggers/) firing | A small Go application which listens for HTTP requests issued as a result of a trigger firing |
 
+
 ## Proposed Examples
 
 The following have been proposed but not implemented:
 
-| Directory | Description |
-| --- | --- |
-| `javascript-api` | A TODO API written and instrumented using JavaScript. |
-| `sidekiq` | Observing behavior of the background job runner Sidekiq. |
-| `honeytail-apache` | Ingesting Apache access logs using Honeytail. |
-| `honeytail-haproxy` | Ingesting HAProxy access logs using Honeytail. |
-| `logstash` | Using the Honeycomb Logstash plugin to send parsed events to Honeycomb. |
-| `fluentd` | Using the Honeycomb Fluentd plugin to send parsed events to Honeycomb. |
+| Directory           | Description                                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| `javascript-api`    | A TODO API written and instrumented using JavaScript.                   |
+| `sidekiq`           | Observing behavior of the background job runner Sidekiq.                |
+| `honeytail-apache`  | Ingesting Apache access logs using Honeytail.                           |
+| `honeytail-haproxy` | Ingesting HAProxy access logs using Honeytail.                          |
+| `logstash`          | Using the Honeycomb Logstash plugin to send parsed events to Honeycomb. |
+| `fluentd`           | Using the Honeycomb Fluentd plugin to send parsed events to Honeycomb.  |
 
 We highly encourage community contribution! Let us know if there's anything you'd like to see
 by [filing an issue](https://github.com/honeycombio/examples/issues/new) and CC-ing Honeycombers

--- a/java-beeline/README.md
+++ b/java-beeline/README.md
@@ -1,0 +1,28 @@
+# beeline-java example web app
+
+This application demonstrates a simple Java Beeline instrumentation of 
+a [Spring Boot](https://projects.spring.io/spring-boot/) application, including adding child spans to traces and custom fields to spans.
+
+## Run locally
+
+### Required configuration
+
+Set your HoneyComb write key and the dataset you want to report to by using the 
+[application.properties](src/main/resources/application.properties) file. 
+
+```
+# (Required) Dataset to send the Events/Spans to
+honeycomb.beeline.dataset                :testDataset
+
+# (Required) Your honeycomb account write key
+honeycomb.beeline.write-key              :testKey
+```
+
+This application requires Java 8.
+
+### Run commands
+
+```sh
+mvn install
+mvn spring-boot:run
+```

--- a/java-beeline/pom.xml
+++ b/java-beeline/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.1.1.RELEASE</version>
+        <relativePath/>
+    </parent>
+    <name>Beeline Java (Examples)</name>
+    <artifactId>beeline-examples</artifactId>
+    <groupId>io.honeycomb.beeline</groupId>
+    <packaging>jar</packaging>
+    <description>
+        Project containing examples of Honeycomb Beeline instrumentation in plain Java and for Spring Boot
+    </description>
+
+    <properties>
+        <java.version>1.8</java.version>
+
+        <beelineVersion>1.0.0-SNAPSHOT</beelineVersion>
+        <wireMockVersion>2.20.0</wireMockVersion>
+        <restAssuredVersion>3.3.0</restAssuredVersion>
+    </properties>
+
+    <dependencies>
+        <!-- COMPILE dependencies -->
+        <dependency>
+            <groupId>io.honeycomb.beeline</groupId>
+            <artifactId>beeline-spring-boot-starter</artifactId>
+            <version>${beelineVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${wireMockVersion}</version>
+        </dependency>
+
+        <!-- TEST dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${restAssuredVersion}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/java/AsyncSpans.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/java/AsyncSpans.java
@@ -1,0 +1,192 @@
+package io.honeycomb.beeline.example.java;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.SpanBuilderFactory;
+import io.honeycomb.beeline.tracing.SpanPostProcessor;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.Tracing;
+import io.honeycomb.beeline.tracing.sampling.Sampling;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.LibHoney;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+/**
+ * This demonstrates instrumenting multi-threaded code using the Beeline and its collaborator classes.
+ * <p>
+ * When using the Beeline in a Spring Boot application all the setup code would be handled by the Beeline
+ * AutoConfiguration.
+ */
+// @formatter:off
+@SuppressWarnings("ALL")
+public class AsyncSpans {
+    private static final String WRITE_KEY = "test-write-key";
+    private static final String DATASET   = "test-dataset";
+
+    private static final Beeline beeline;
+    private static final HoneyClient client;
+
+    static {
+        client                          = LibHoney.create(LibHoney.options().setDataset(DATASET).setWriteKey(WRITE_KEY).build());
+        SpanPostProcessor postProcessor = Tracing.createSpanProcessor(client, Sampling.alwaysSampler());
+        SpanBuilderFactory factory      = Tracing.createSpanBuilderFactory(postProcessor, Sampling.alwaysSampler());
+        Tracer tracer                   = Tracing.createTracer(factory);
+        beeline                         = Tracing.createBeeline(tracer, factory);
+    }
+
+    private HttpClient httpClient = new HttpClient();
+    private String requestUrl = "https://example.com";
+
+    public static void main(String... args) throws Exception {
+        AsyncSpans examples = new AsyncSpans();
+        Span rootSpan = beeline.getSpanBuilderFactory()
+            .createBuilder()
+            .setSpanName("base-span")
+            .setServiceName("async-service")
+            .build();
+
+        try(Span tracedSpan = beeline.getTracer().startTrace(rootSpan)) {
+            examples.run();
+        } finally{
+            // close to flush events and release its thread pool
+            client.close();
+        }
+    }
+
+    /**
+     * Runs the various examples. They all create children to the root span created in the main method.
+     */
+    void run() throws Exception {
+        futureChain();
+
+        singleLambda();
+
+        multipleSpansInAPipeline();
+
+        submitCallable();
+
+        submitRunnable();
+    }
+
+    /**
+     * This demonstrates how one could create a "detached" Span to cover a CompletableFuture chain.
+     * <p>
+     * We cannot simply use {@link Beeline#getActiveSpan()}, which uses thread-locals, within the CompletableFuture,
+     * because runAsync will run the task on a different thread
+     */
+    private void futureChain() {
+        // create a child span that is not lonked to the Beeline's thread local context.
+        Span httpServiceSpan = beeline.getTracer().startDetachedChildSpan("http-call-futureChain");
+
+        httpServiceSpan.addField("http-request-url", requestUrl);
+
+        CompletableFuture
+            // start measuring duration when execution of the task starts
+            .runAsync(httpServiceSpan::markStart)
+
+            // perform operations
+            .thenApply((v) -> httpClient.get(requestUrl))
+            .thenApply(this::convertResponse)
+            .thenApply(this::handleResponse)
+
+            // add any error that might have occured in the above steps
+            .exceptionally(e -> httpServiceSpan.addField("error-message", e.getMessage()))
+
+            // close and submit span to honeycomb
+            .thenRun(httpServiceSpan::close);
+    }
+
+    /**
+     * This is functionally the same as the "futureChain" example except that it we turned the chain into a single
+     * lambda.
+     */
+    private void singleLambda() {
+        Span httpServiceSpan = beeline.getTracer().startDetachedChildSpan("http-call-lambda");
+
+        httpServiceSpan.addField("http-request-url", requestUrl);
+        CompletableFuture
+            .runAsync(() -> {
+                httpServiceSpan.markStart();
+                try {
+                    String rawResponse = httpClient.get(requestUrl);
+                    String response = convertResponse(rawResponse);
+                    handleResponse(response);
+                } catch (Throwable e) {
+                    httpServiceSpan.addField("error-message", e.getMessage());
+                } finally {
+                    httpServiceSpan.close();
+                }
+            });
+    }
+
+    /**
+     * In the "futureChain" and "singleLambda" examples we create a detached child Span, because we run the task on a
+     * different thread, However, we can also propagate the thread-local context of the Beeline to the new thread,
+     * and use it inside the task, by wrapping the task Runnable.
+     */
+    private void submitRunnable() throws ExecutionException, InterruptedException {
+        Runnable task = () -> {
+            beeline.getActiveSpan().addField("http-request-url", requestUrl);
+            httpClient.get(requestUrl);
+        };
+
+        Runnable tracedTask = beeline.getTracer().traceRunnable("http-call-runnable", task);
+
+        ExecutorService executorService = newSingleThreadExecutor();
+        executorService.submit(tracedTask).get();
+        executorService.shutdownNow();
+    }
+
+    /**
+     * Same as the "submitRunnable" example, except with a Callable. This simply demonstrates that different "functional
+     * interfaces" that are supported.
+     */
+    private void submitCallable() throws ExecutionException, InterruptedException {
+        Callable<String> task = () -> {
+            beeline.getActiveSpan().addField("http-request-url", requestUrl);
+            return httpClient.get(requestUrl);
+        };
+
+        Callable<String> tracedTask = beeline.getTracer().traceCallable("http-call-callable", task);
+
+        ExecutorService executorService = newSingleThreadExecutor();
+        executorService.submit(tracedTask).get();
+        executorService.shutdownNow();
+    }
+
+    /**
+     * This further demonstrates that Supplier and Function can also be wrapped.
+     * In contrast to the "futureChain" example, this would create 3 Span children for each wrapped lambda.
+     */
+    private void multipleSpansInAPipeline() {
+        CompletableFuture
+            .supplyAsync(
+                beeline.getTracer().traceSupplier("http-call-first", () -> httpClient.get(requestUrl)))
+            .thenApplyAsync(
+                beeline.getTracer().traceFunction("http-call-conversion", this::convertResponse))
+            .thenApplyAsync(
+                beeline.getTracer().traceFunction("http-call-handle", this::handleResponse));
+    }
+
+    // placeholders to make the examples above look more "realistic"
+    private String convertResponse(String s) {
+        return "";
+    }
+
+    private Object handleResponse(String response) {
+        return "";
+    }
+
+    public static class HttpClient {
+        public String get(String requestUrl) {
+            return "mock response";
+        }
+    }
+}
+

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/java/ManualSpans.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/java/ManualSpans.java
@@ -1,0 +1,102 @@
+package io.honeycomb.beeline.example.java;
+
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.SpanBuilderFactory;
+import io.honeycomb.beeline.tracing.SpanPostProcessor;
+import io.honeycomb.beeline.tracing.Tracing;
+import io.honeycomb.beeline.tracing.propagation.HttpHeaderV1PropagationCodec;
+import io.honeycomb.beeline.tracing.propagation.Propagation;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.honeycomb.beeline.tracing.sampling.Sampling;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.LibHoney;
+
+/**
+ * This shows how one could manually propagate Spans. This is in contrast with the examples in {@link TracerSpans} or
+ * {@link AsyncSpans}, which use the convenience of the Beeline and its collaborator classes to do so.
+ * <p>
+ * When using the Beeline in a Spring Boot application all the setup code would be handled by the Beeline
+ * AutoConfiguration.
+ */
+// @formatter:off
+@SuppressWarnings("ALL")
+public class ManualSpans {
+    private static final String WRITE_KEY = "test-write-key";
+    private static final String DATASET   = "test-dataset";
+
+    private static final SpanBuilderFactory factory;
+    private static final HoneyClient client;
+    static {
+        client                          = LibHoney.create(LibHoney.options().setDataset(DATASET).setWriteKey(WRITE_KEY).build());
+        SpanPostProcessor postProcessor = Tracing.createSpanProcessor(client, Sampling.alwaysSampler());
+        factory                         = Tracing.createSpanBuilderFactory(postProcessor, Sampling.alwaysSampler());
+    }
+
+    public static void main(String... args){
+        ManualSpans example = new ManualSpans();
+        HttpRequest request = new HttpRequest();
+        try(Span rootSpan = startTrace(request)) {
+            example.acceptRequest(request, rootSpan);
+        } finally {
+            client.close(); // close to flush events and release its thread pool
+        }
+    }
+
+    private static Span startTrace(HttpRequest request) {
+        // extract propagated trace from header, if it exists
+        String headerValue = request.getHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER);
+        PropagationContext context = Propagation.honeycombHeaderV1().decode(headerValue);
+
+        // set up root span with some context data
+        return factory.createBuilder()
+            .setSpanName("get-customer-data")
+            .setServiceName("customer-db-manual")
+            .setParentContext(context)
+            .addField("request-uri", request.getRequestURI())
+            .addField("customer-id", request.getParameter("customer-id"))
+            .build();
+    }
+
+    private DatabaseService db = new DatabaseService();
+
+    // @RequestMapping
+    public void acceptRequest(HttpRequest request, Span span) {
+        try {
+            db.queryDb(request.getParameter("customer_id"), span);
+            span.addField("result", "OK");
+        } catch (Exception e) {
+            span.addField("result", "Bad Request")
+                    .addField("exception-message", e.getMessage());
+        }
+    }
+
+    public static class DatabaseService {
+        public void queryDb(String id, Span parentSpan) {
+            SpanBuilderFactory.SpanBuilder spanBuilder = factory.createBuilderFromParent(parentSpan).setSpanName("customer-db-query");
+            try (Span childSpan = spanBuilder.build()) {
+                String data = getCustomerDataById(id);
+                childSpan.addField("customer-data", data);
+            }
+
+        }
+
+        public String getCustomerDataById(String id) {
+            return "customer-0123";
+        }
+
+    }
+
+    private static class HttpRequest {
+        public String getHeader(String key) {
+            return "mockHeader";
+        }
+
+        public String getRequestURI() {
+            return "mockHeader";
+        }
+
+        public String getParameter(String key) {
+            return "mockParameter";
+        }
+    }
+}

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/java/TracerSpans.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/java/TracerSpans.java
@@ -1,0 +1,106 @@
+package io.honeycomb.beeline.example.java;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.SpanBuilderFactory;
+import io.honeycomb.beeline.tracing.SpanPostProcessor;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.Tracing;
+import io.honeycomb.beeline.tracing.propagation.HttpHeaderV1PropagationCodec;
+import io.honeycomb.beeline.tracing.propagation.Propagation;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.honeycomb.beeline.tracing.sampling.Sampling;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.LibHoney;
+
+/**
+ * This shows how one could manually propagate Spans. This is in contrast with the examples in {@link TracerSpans} or
+ * {@link AsyncSpans}, which use the convenience of the Beeline and its collaborator classes to do so.
+ * <p>
+ * When using the Beeline in a Spring Boot application all the setup code would be handled by the Beeline
+ * AutoConfiguration.
+ */
+// @formatter:off
+@SuppressWarnings("ALL")
+public class TracerSpans {
+    private static final String WRITE_KEY = "test-write-key";
+    private static final String DATASET   = "test-dataset";
+
+    private static final HoneyClient client;
+    private static final Beeline beeline;
+
+    static {
+        client                          = LibHoney.create(LibHoney.options().setDataset(DATASET).setWriteKey(WRITE_KEY).build());
+        SpanPostProcessor postProcessor = Tracing.createSpanProcessor(client, Sampling.alwaysSampler());
+        SpanBuilderFactory factory      = Tracing.createSpanBuilderFactory(postProcessor, Sampling.alwaysSampler());
+        Tracer tracer                   = Tracing.createTracer(factory);
+        beeline                         = Tracing.createBeeline(tracer, factory);
+    }
+
+    public static void main(String... args) {
+        TracerSpans example = new TracerSpans();
+        try {
+            HttpRequest request = new HttpRequest();
+            startTrace(request);
+            example.acceptRequest(request);
+        } finally {
+            beeline.getTracer().endTrace();
+            client.close(); // close to flush events and release its thread pool
+        }
+    }
+
+    private DatabaseService db = new DatabaseService();
+
+    private static void startTrace(HttpRequest request) {
+        String headerValue = request.getHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER);
+        PropagationContext context = Propagation.honeycombHeaderV1().decode(headerValue);
+
+        Span rootSpan = beeline.getSpanBuilderFactory().createBuilder()
+            .setSpanName("get-customer-data")
+            .setServiceName("customer-db-traced")
+            .setParentContext(context)
+            .build();
+        beeline.getTracer().startTrace(rootSpan);
+    }
+
+    // @RequestMapping
+    public void acceptRequest(HttpRequest request) {
+        Span span = beeline.getActiveSpan();
+        try {
+            db.queryDb(request.getParameter("customer-id"));
+            span.addField("result", "OK");
+        } catch (Exception e) {
+            span.addField("result", "Bad Request")
+                .addField("exception-message", e.getMessage());
+        }
+    }
+
+    public static class DatabaseService {
+        public void queryDb(String id) {
+            try (Span childSpan = beeline.startChildSpan("customer-db-query")) {
+                String data = getCustomerDataById(id);
+                childSpan.addField("customer-data", data);
+            }
+
+        }
+
+        public String getCustomerDataById(String id) {
+            return "customer-0123";
+        }
+
+    }
+
+    private static class HttpRequest {
+        public String getHeader(String key) {
+            return "mockHeader";
+        }
+
+        public String getRequestURI() {
+            return "mockHeader";
+        }
+
+        public String getParameter(String key) {
+            return "mockParameter";
+        }
+    }
+}

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/DemoApplication.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/DemoApplication.java
@@ -1,0 +1,63 @@
+package io.honeycomb.beeline.example.spring;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PreDestroy;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+@SuppressWarnings("ALL")
+@SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String... args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Create an instrumented rest template.
+    // The Beeline AutoConfiguration wires itself into the RestTemplateBuilder.
+    ///////////////////////////////////////////////////////////////////////////
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Start up a mock server (running on localhost:8089) that stubs Honeycomb's Events API.
+    // We target it with the "honeycomb.beeline.api-host" property.
+    ///////////////////////////////////////////////////////////////////////////
+    @Autowired
+    WireMockServer mockServer;
+
+    @PreDestroy
+    public void closeMock() {
+        mockServer.stop();
+    }
+
+    @Bean(destroyMethod = "")
+    public WireMockServer honeycombMock() {
+        WireMockServer honeycombMock = new WireMockServer(WireMockConfiguration.options()
+            .port(8089)
+            .notifier(new Slf4jNotifier(false)));
+        honeycombMock.start();
+        stubEventsEndpoint(honeycombMock);
+        return honeycombMock;
+    }
+
+    private static void stubEventsEndpoint(WireMockServer honeycombMock) {
+        honeycombMock.stubFor(post(urlPathMatching("/1/batch/.*"))
+            .willReturn(aResponse().withBody("[{\"status\": 202},{\"status\": 202}, {\"status\": 202}, {\"status\": 202}, {\"status\": 202}, {\"status\": 202}, {\"status\": 202}]")));
+    }
+}
+

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/DemoForwardingController.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/DemoForwardingController.java
@@ -1,0 +1,20 @@
+package io.honeycomb.beeline.example.spring;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@SuppressWarnings("ALL")
+@Controller
+public class DemoForwardingController {
+    /**
+     * Forward call to another endpoint, showing nesting of Spans when performing a "forward dispatch".
+     *
+     * @param redirectPath to use when forwarding.
+     * @return forward.
+     */
+    @RequestMapping("/forward-to/{redirectPath}")
+    String forwardingEndpoint(@PathVariable String redirectPath) {
+        return "forward:/" + redirectPath;
+    }
+}

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/DemoRestController.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/DemoRestController.java
@@ -1,0 +1,106 @@
+package io.honeycomb.beeline.example.spring;
+
+import io.honeycomb.beeline.example.spring.data.CustomerData;
+import io.honeycomb.beeline.example.spring.services.AspectAnnotatedComponent;
+import io.honeycomb.beeline.example.spring.services.ExampleHttpService;
+import io.honeycomb.beeline.spring.beans.aspects.ChildSpan;
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@SuppressWarnings("ALL")
+@RestController
+public class DemoRestController {
+    @Autowired
+    Beeline beeline;
+
+    @Autowired
+    AspectAnnotatedComponent component;
+
+    @Autowired
+    ExampleHttpService exampleHttpService;
+
+    /**
+     * Make HTTP client call to example.com, demonstrating server + client spans.
+     *
+     * @return the HTML response.
+     */
+    @RequestMapping(value = "/get-example", produces = MediaType.TEXT_HTML_VALUE)
+    String getExamplePage() {
+        return exampleHttpService.getExampleContent();
+    }
+
+    /**
+     * Concatenate query parameters (or use the default value).
+     * Shows how the "request.query" field is populated.
+     *
+     * @param firstWord  to concatenate.
+     * @param secondWord to concatenate.
+     * @return the concatenation.
+     */
+    @RequestMapping("/concatenate-words")
+    String concatenateWords(@RequestParam(name = "first-word", defaultValue = "Hello") String firstWord,
+                            @RequestParam(name = "second-word", defaultValue = "World") String secondWord) {
+        String result = firstWord.toUpperCase() + " " + secondWord.toUpperCase();
+        beeline.getActiveSpan()
+            .addField("result", result)
+            .addField("result-length", result.length());
+        return result;
+    }
+
+    /**
+     * Throws an exception, which demonstrates the capture of error details.
+     *
+     * @return nothing.
+     * @throws RuntimeException to demonstrate error details.
+     */
+    @RequestMapping("/throw-exception")
+    String throwException() {
+        throw new RuntimeException("Found an error!");
+    }
+
+    /**
+     * @return some json data.
+     */
+    @RequestMapping("/get-captains-data")
+    CustomerData getCustomerData() {
+        CustomerData customerData = new CustomerData();
+        customerData.setName("James T. Kirk");
+        customerData.setAge(53);
+        return customerData;
+    }
+
+    /**
+     * Call into an AOP-annotated service, demonstrating declarative child spans.
+     *
+     * @return a random captain.
+     */
+    // Since controllers are just Spring beans, they are also subject to AOP, so will get an additional Span here.
+    @ChildSpan("PickACaptain")
+    @RequestMapping("/pick-a-captain")
+    String getARandomCaptain() {
+        Span activeSpan = beeline.getActiveSpan().addField("controller-reached", true);
+
+        // Both methods of the "component" are annotated to generate child spans
+        String chosenCaptain = component.pickARandomCaptain("Picard", "Kirk", "Pike", "Sisko", "Janeway", "Archer");
+        activeSpan.addField("intermediate-result", chosenCaptain);
+
+        String titleAndName = component.prefixWithTitle("Captain", chosenCaptain);
+        activeSpan.addField("final-result", chosenCaptain);
+
+        return titleAndName;
+    }
+
+    /**
+     * The service hands off to other threads and returns early. This shows how async spans can outlive the root.
+     */
+    @RequestMapping("/run-async-tasks")
+    void asyncTask() {
+        Span activeSpan = beeline.getActiveSpan().addField("controller-reached", true);
+        component.runAsyncTasks();
+    }
+}

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/data/CustomerData.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/data/CustomerData.java
@@ -1,0 +1,22 @@
+package io.honeycomb.beeline.example.spring.data;
+
+public class CustomerData {
+    private String name;
+    private int age;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/services/AspectAnnotatedComponent.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/services/AspectAnnotatedComponent.java
@@ -1,0 +1,85 @@
+package io.honeycomb.beeline.example.spring.services;
+
+import io.honeycomb.beeline.spring.beans.aspects.ChildSpan;
+import io.honeycomb.beeline.spring.beans.aspects.SpanField;
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Tracer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@SuppressWarnings("ALL")
+@Component
+public class AspectAnnotatedComponent {
+    @Autowired
+    Beeline beeline;
+
+    /**
+     * Declaratively generate a child span when the method is invoked. The Span name is inferred from the method name.
+     * Additionally, the annotation requests that the return value is added as a field.
+     *
+     * @param captains to pick from.
+     * @return one of the captains.
+     */
+    @ChildSpan(addResult = true)
+    public String pickARandomCaptain(String... captains) {
+        addLatency(100);
+        return captains[(int) (Math.random() * captains.length)];
+    }
+
+    /**
+     * Demonstrates that an explicit Span name can be set, and that the arguments can declaratively be captured.
+     *
+     * @param title       to use a prefix to the name.
+     * @param captainName to use.
+     * @return title + name.
+     */
+    @ChildSpan("Add-Title-To-Name")
+    public String prefixWithTitle(@SpanField("captain-title") String title, @SpanField String captainName) {
+        addLatency(100);
+        return title + " " + captainName;
+    }
+
+    /**
+     * Demonstrates propagation to other threads and how async spans can outlive the root.
+     * There are various calls to Thread.sleep to make the span durations more "realistic".
+     */
+    @ChildSpan
+    public void runAsyncTasks() {
+        addLatency(100);
+        final Tracer tracer = beeline.getTracer();
+
+        CompletableFuture.runAsync(tracer.traceRunnable("task-1", () -> {
+            addLatency(300);
+            beeline.getActiveSpan().addField("task", 1);
+        }));
+        CompletableFuture.runAsync(tracer.traceRunnable("task-2", () -> {
+            addLatency(200);
+            beeline.getActiveSpan().addField("task", 2);
+        }));
+
+        addLatency(300);
+        CompletableFuture
+            .runAsync(tracer.traceRunnable("task-3-1", () -> {
+                addLatency(300);
+                beeline.getActiveSpan().addField("task", 3.1);
+            }))
+            .thenRun(tracer.traceRunnable("task-3-2", () -> {
+                addLatency(300);
+                beeline.getActiveSpan().addField("task", 3.2);
+            }));
+        addLatency(100);
+    }
+
+    /**
+     * Creates some latency to make Span times more realistic.
+     */
+    private void addLatency(int waitMultiplyer) {
+        try {
+            Thread.sleep((long) (Math.random() * waitMultiplyer));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/services/ExampleHttpService.java
+++ b/java-beeline/src/main/java/io/honeycomb/beeline/example/spring/services/ExampleHttpService.java
@@ -1,0 +1,29 @@
+package io.honeycomb.beeline.example.spring.services;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@SuppressWarnings("ALL")
+@Component
+public class ExampleHttpService {
+    private static final Logger LOG = LoggerFactory.getLogger(ExampleHttpService.class);
+
+    private static final String EXAMPLE_COM_URL = "http://www.example.com";
+
+    @Autowired
+    Beeline beeline;
+
+    @Autowired
+    RestTemplate client;
+
+    public String getExampleContent() {
+        String response = client.getForObject(EXAMPLE_COM_URL, String.class);
+        LOG.info("Received response from example.com: {}", response.substring(0, 100));
+        beeline.getActiveSpan().addField("example-response-substring", response.substring(0, 100));
+        return response;
+    }
+}

--- a/java-beeline/src/main/resources/application.properties
+++ b/java-beeline/src/main/resources/application.properties
@@ -1,0 +1,36 @@
+# These are the available configuration properties for a Spring Boot app instrumented with the Beeline.
+# Each property has additional javadoc/configuration metadata associated with it.
+
+# (Required) Give your application a name to identify the origin of your Honeycomb Events/Spans
+honeycomb.beeline.service-name           :DemoApplication
+
+# (Required) Dataset to send the Events/Spans to
+honeycomb.beeline.dataset                :testDataset
+
+# (Required) Your honeycomb account write key
+honeycomb.beeline.write-key              :testKey
+
+# (Optional) Sets the global sample rate of traces.
+honeycomb.beeline.sample-rate            :1
+
+# (Optional) Allows the entire Beeline AutoConfiguration to be disabled completely.
+honeycomb.beeline.enabled                :true
+
+# (Optional) Allows to switch off automatic instrumentation of the RestTemplate.
+honeycomb.beeline.rest-template.enabled  :true
+
+# (Optional) Allows overriding of the beeline's servlet filter precedence
+# - in case you want your own filters to come before it.
+#honeycomb.beeline.filter-order:
+
+# (Optional) Enables a form of debug logging of responses from Honeycomb's server
+honeycomb.beeline.log-honeycomb-responses:false
+
+# (Optional) List of paths that should be subject to tracing (ant path pattern)
+honeycomb.beeline.include-path-patterns  :/**
+
+# (Optional) List of paths that should not be subject to tracing (ant path pattern)
+honeycomb.beeline.exclude-path-patterns  :/exclude-this-path
+
+# (Optional) For testing you can override Honeycomb's hostname and redirect Events/Spans.
+#honeycomb.beeline.api-host=http://localhost:8089

--- a/java-beeline/src/test/java/io/honeycomb/beeline/example/spring/DemoApplicationTests.java
+++ b/java-beeline/src/test/java/io/honeycomb/beeline/example/spring/DemoApplicationTests.java
@@ -1,0 +1,57 @@
+package io.honeycomb.beeline.example.spring;
+
+import io.honeycomb.beeline.tracing.ids.TraceIdProvider;
+import io.honeycomb.beeline.tracing.ids.UUIDTraceIdProvider;
+import io.honeycomb.beeline.tracing.propagation.HttpHeaderV1PropagationCodec;
+import io.honeycomb.beeline.tracing.propagation.Propagation;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.restassured.RestAssured;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collections;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.startsWith;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class DemoApplicationTests {
+
+    @LocalServerPort
+    int port;
+
+    @Before
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    public void checkThatContextInitializesCorrectly() {
+
+    }
+
+    @Test
+    public void checkThatRequestWorkd() {
+        TraceIdProvider idProvider = UUIDTraceIdProvider.getInstance();
+        final String traceId = idProvider.generateId();
+        final String spanId = idProvider.generateId();
+        final PropagationContext context = new PropagationContext(traceId, spanId, null, Collections.singletonMap("env", "test"));
+        final String encode = Propagation.honeycombHeaderV1().encode(context).get();
+
+        given()
+            .header(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, encode)
+
+            .when().get("/forward-to/{forwardingPath}", "pick-a-captain")
+
+            .then().body(startsWith("Captain"));
+    }
+
+}
+

--- a/java-beeline/src/test/resources/application-test.properties
+++ b/java-beeline/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+# Silences logs
+logging.level.root: ERROR
+spring.main.banner-mode:off
+
+honeycomb.beeline.service-name=DemoApplication
+honeycomb.beeline.dataset=testDataset
+honeycomb.beeline.write-key=testKey
+honeycomb.beeline.api-host=http://localhost:8089
+#debug:true

--- a/java-beeline/src/test/resources/logback-test.xml
+++ b/java-beeline/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework" level="ERROR"/>
+    <logger name="io.honeycomb.libhoney" level="ERROR"/>
+    <logger name="io.honeycomb.beeline.spring" level="ERROR"/>
+</configuration>


### PR DESCRIPTION
These were examples created by Salmon to illustrate how to use the java-beeline to instrument a SpringBoot app for tracing.