### PR TITLE
Fix `python-api` example.

### DIFF
--- a/python-api/Dockerfile
+++ b/python-api/Dockerfile
@@ -3,10 +3,12 @@ FROM python:alpine
 RUN mkdir -p /opt/python-api
 WORKDIR /opt/python-api
 COPY requirements.txt requirements.txt
-RUN apk add --no-cache --virtual build-deps mariadb-dev build-base \
-    && pip install -r requirements.txt \
-    && apk add --virtual .runtime-deps mariadb-client-libs \
-    && apk del build-deps
+RUN apk add --no-cache mariadb-connector-c-dev mariadb-connector-c ;\
+    apk add --no-cache --virtual .build-deps \
+        build-base \
+        mariadb-dev ;\
+    pip install -r requirements.txt ;\
+    apk del .build-deps
 RUN pip install -r requirements.txt
 ENV FLASK_APP=app.py
 COPY app.py app.py

--- a/python-api/docker-compose.yml
+++ b/python-api/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       DB_HOST: db
       HONEYCOMB_WRITEKEY: 
     restart: on-failure
+    depends_on:
+      - "db"
 
   db:
     image: mysql
@@ -21,6 +23,7 @@ services:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "example-python-api"
+    command: ["mysqld", "--default-authentication-plugin", "mysql_native_password"]
 
 volumes:
   example-python-api:


### PR DESCRIPTION
This example isn't working dockerized as it downloads latest versions of both `alpine` and `MySQL` and there are some thing that are not compatbile (e.g. the `mariadb-client-libs` package no longer exists in alpine versions > `3.7`). Also, MySQL 8 won't work because it uses by default the `caching_sha2_password` plugin so you have to make it explicit you want to use `mysql_native_password`.