### PR TITLE
add trigger description to webhook example

### DIFF
--- a/webhook-listener-triggers/README.md
+++ b/webhook-listener-triggers/README.md
@@ -12,6 +12,7 @@ Here's an example of a notification that Honeycomb Triggers would send and this 
   "version": "v0.1.0",
   "id": "abdcefg",
   "name": "trig on ttt",
+  "trigger_description": "To troubleshoot, please look up the steps in our runbook",
   "trigger_url": "https://ui.honeycomb.io/team/datasets/dataset/triggers/abdcefg",
   "status": "TRIGGERED",
   "summary": "Triggered: trig on ttt",

--- a/webhook-listener-triggers/main.go
+++ b/webhook-listener-triggers/main.go
@@ -53,7 +53,8 @@ type Notification struct {
 	SharedSecret string `json:"shared_secret"`
 	// TriggerName is the name of this trigger, as configured in the UI
 	TriggerName string `json:"name"`
-        TriggerID string   `json:"id"`
+	TriggerID string   `json:"id"`
+	TriggerDescription string `json:"trigger_description"`
 	// Status will be TRIGGERED or OK
 	Status          string          `json:"status"`
 	Summary         string          `json:"summary"`


### PR DESCRIPTION
We recently added trigger description to the webhook payload. Adding it here as well to keep this documentation up to date.