### PR TITLE
Add python-otlp example

### DIFF
--- a/python-otlp/app.py
+++ b/python-otlp/app.py
@@ -1,0 +1,38 @@
+import flask
+import requests
+
+from grpc import ssl_channel_credentials
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+
+otlp_exporter = OTLPSpanExporter(
+	endpoint="api.honeycomb.io:443",
+	credentials=ssl_channel_credentials(),
+	headers=(("x-honeycomb-team", ""),("x-honeycomb-dataset","test-otlp"))
+)
+
+trace.set_tracer_provider(TracerProvider(resource=Resource({"service.name": "python-otlp", "service.version":"0.1"})))
+trace.get_tracer_provider().add_span_processor(
+    SimpleExportSpanProcessor(otlp_exporter)
+)
+
+app = flask.Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
+RequestsInstrumentor().instrument()
+
+
+@app.route("/")
+def hello():
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("example-request"):
+        requests.get("http://www.example.com")
+    return "hello"
+
+
+app.run(debug=True, port=5000)

--- a/python-otlp/requirements.txt
+++ b/python-otlp/requirements.txt
@@ -1,0 +1,6 @@
+flask
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-instrumentation-flask
+opentelemetry-instrumentation-requests
+opentelemetry-exporter-otlp


### PR DESCRIPTION
Adds example python flask app that sends data to Honeycomb using the OTLP exporter.