### PR TITLE
Add ruby-otlp example

### DIFF
--- a/ruby-otlp/Gemfile
+++ b/ruby-otlp/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "sinatra"
+gem "opentelemetry-api"
+gem "opentelemetry-sdk"
+gem "opentelemetry-exporter-otlp"

--- a/ruby-otlp/Gemfile.lock
+++ b/ruby-otlp/Gemfile.lock
@@ -1,0 +1,38 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    google-protobuf (3.14.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    opentelemetry-api (0.11.0)
+    opentelemetry-common (0.11.0)
+      opentelemetry-api (~> 0.11.0)
+    opentelemetry-exporter-otlp (0.11.0)
+      google-protobuf (>= 3.4.1.1, < 4)
+      opentelemetry-api (~> 0.11.0)
+      opentelemetry-common (~> 0.11.0)
+    opentelemetry-sdk (0.11.1)
+      opentelemetry-api (~> 0.11.0)
+      opentelemetry-common (~> 0.11.0)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    ruby2_keywords (0.0.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  opentelemetry-api
+  opentelemetry-exporter-otlp
+  opentelemetry-sdk
+  sinatra
+
+BUNDLED WITH
+   2.1.4

--- a/ruby-otlp/README.md
+++ b/ruby-otlp/README.md
@@ -1,0 +1,20 @@
+# Honeycomb OpenTelemetry OTLP example
+
+This is a simple example Sinatra web server that uses OpenTelemetry to generate trace data and send to Honeycomb using the OTLP exporter.
+
+The [Ruby OpenTelemetry OTLP exporter](https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/otlp) currently only works over HTTP with JSON and the Honeycomb ingest API only works over gRPC. This means we need to
+setup and run a collector to receive the trace data over JSON and then send to Honeycomb over gRPC.
+
+The simplest way to run a collector is to use the offical OpenTelemetry Collector Docker image and pass in the configuration file. First edit the config to provide your Honeycomb API Key and dataset name. Then run the following to start the collector:
+
+```
+docker run --rm -p 55680-55681:55680-55681 -v "${PWD}/collector-config.yaml":/collector-config.yaml otel/opentelemetry-collector --config collector-config.yaml
+```
+
+Once the collector is up and running, you then can run the ruby app with the following:
+```
+bundle install
+ruby app.rb
+```
+
+Finally, open `http://localhost:4567` to generate some trace data that will be visble in the [Honeycomb UI](http://ui.honeycomb.io).

--- a/ruby-otlp/app.rb
+++ b/ruby-otlp/app.rb
@@ -1,0 +1,67 @@
+require 'sinatra/base'
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+
+
+# configure SDK with OTLP exporter
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      exporter: OpenTelemetry::Exporter::OTLP::Exporter.new(
+		endpoint: 'localhost:55681/v1/trace', # send to local collector
+		insecure: true
+      )
+    )
+  )
+end
+
+class OpenTelemetryMiddleware
+	def initialize(app)
+	  @app = app
+	  @tracer = OpenTelemetry.tracer_provider.tracer('sinatra', '1.0')
+	end
+
+	def call(env)
+		# Extract context from request headers
+		context = OpenTelemetry.propagation.http.extract(env)
+
+		status, headers, response_body = 200, {}, ''
+
+		# Span name SHOULD be set to route:
+		span_name = env['PATH_INFO']
+
+		# For attribute naming, see
+		# https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md#http-server
+
+		# Span kind MUST be `:server` for a HTTP server span
+		@tracer.in_span(
+		  span_name,
+		  attributes: {
+			'component' => 'http',
+			'http.method' => env['REQUEST_METHOD'],
+			'http.route' => env['PATH_INFO'],
+			'http.url' => env['REQUEST_URI'],
+		  },
+		  kind: :server,
+		  with_parent: context
+		) do |span|
+		  # Run application stack
+		  status, headers, response_body = @app.call(env)
+
+		  span.set_attribute('http.status_code', status)
+		end
+
+		[status, headers, response_body]
+	  end
+end
+
+class App < Sinatra::Base
+  set :bind, '0.0.0.0'
+  use OpenTelemetryMiddleware
+
+  get '/' do
+	'Hello world!'
+  end
+
+  run! if app_file == $0
+end

--- a/ruby-otlp/collector-config.yaml
+++ b/ruby-otlp/collector-config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp:
+    endpoint: api.honeycomb.io:443
+    headers:
+      "x-honeycomb-team": ""
+      "x-honeycomb-dataset": ""
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]


### PR DESCRIPTION
Adds a ruby app that can send trace data to Honeycomb using the OTLP exporter.

**NOTE**: The Ruby OTLP exporter does not currently support sending trace data over gRPC so we need use a local collector that receives JSON and sends out over gRPC. The example includes a collector config that can be used to run a local docker image that can forward data to Honeycomb.