### PR TITLE
Tidy up OTLP examples

### DIFF
--- a/dotnet-otlp/README.md
+++ b/dotnet-otlp/README.md
@@ -1,0 +1,13 @@
+
+# Honeycomb OpenTelemetry OTLP example
+
+This is a simple .NET core web app that uses OpenTelemetry to generate trace data and send to Honeycomb using the OTLP exporter.
+
+First you need to edit [appsettings.json](./appsettings.json) to set your Honeycomb API key and dataset.
+
+Then run the web app:
+```
+dotnet run
+```
+
+Finally, open `http://localhost:5000` to generate some trace data that will be visble in the [Honeycomb UI](http://ui.honeycomb.io).

--- a/dotnet-otlp/Startup.cs
+++ b/dotnet-otlp/Startup.cs
@@ -51,7 +51,7 @@ namespace dotnet_otlp
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapGet("/hello", async context =>
+                endpoints.MapGet("/", async context =>
                 {
                     await context.Response.WriteAsync("Hello World!");
                 });

--- a/dotnet-otlp/appsettings.json
+++ b/dotnet-otlp/appsettings.json
@@ -11,6 +11,6 @@
     "ServiceName": "dotnet-otlp",
     "Endpoint": "api.honeycomb.io",
     "ApiKey": "",
-    "Dataset": "test-otlp"
+    "Dataset": ""
   }
 }

--- a/golang-otlp/README.md
+++ b/golang-otlp/README.md
@@ -1,0 +1,11 @@
+
+# Honeycomb OpenTelemetry OTLP example
+
+This is a simple golang web app that uses OpenTelemetry to generate trace data and send to Honeycomb using the OTLP exporter.
+
+Run the web app and pass in youe API key and dataset:
+```
+go run main.go -apikey <your-apikey> -dataset <dataset-name>
+```
+
+Next, open `http://localhost:8080` to generate some trace data that will be visble in the [Honeycomb UI](http://ui.honeycomb.io).

--- a/golang-otlp/main.go
+++ b/golang-otlp/main.go
@@ -59,9 +59,9 @@ func main() {
 		_, _ = io.WriteString(w, "Hello, world!\n")
 	}
 
-	log.Println("listening at http://localhost:7778/hello")
-	http.Handle("/hello", otelhttp.NewHandler(http.HandlerFunc(helloHandler), "Hello"))
-	err := http.ListenAndServe(":7778", nil)
+	log.Println("listening at http://localhost:8080")
+	http.Handle("/", otelhttp.NewHandler(http.HandlerFunc(helloHandler), ""))
+	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/java-beeline/.gitignore
+++ b/java-beeline/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+target
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/java-otlp/README.md
+++ b/java-otlp/README.md
@@ -1,0 +1,13 @@
+
+# Honeycomb OpenTelemetry OTLP example
+
+This is a simple Java web app that uses OpenTelemetry to generate trace data and send to Honeycomb using the OTLP exporter.
+
+First you need to edit [JavaOtlpApplication.java](./src/main/java/io/honeycomb/examples/javaotlp/JavaOtlpApplication.java) to set your Honeycomb API key and dataset.
+
+Then run the web app:
+```
+./gradlew bootRun
+```
+
+Finally, open `http://localhost:8080` to generate some trace data that will be visble in the [Honeycomb UI](http://ui.honeycomb.io).

--- a/java-otlp/src/main/java/io/honeycomb/examples/javaotlp/JavaOtlpApplication.java
+++ b/java-otlp/src/main/java/io/honeycomb/examples/javaotlp/JavaOtlpApplication.java
@@ -26,7 +26,7 @@ public class JavaOtlpApplication {
 			.setEndpoint("api.honeycomb.io:443")
 			.setUseTls(true)
 			.addHeader("x-honeycomb-team", "")
-			.addHeader("x-honeycomb-dataset", "test-otlp")
+			.addHeader("x-honeycomb-dataset", "")
 			.build();
 
 		// Configure the OpenTelemtry SDK with the exporter

--- a/java-webapp/.gitignore
+++ b/java-webapp/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+target
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/python-otlp/README.md
+++ b/python-otlp/README.md
@@ -1,0 +1,13 @@
+
+# Honeycomb OpenTelemetry OTLP example
+
+This is a simple Python flask web app that uses OpenTelemetry to generate trace data and send to Honeycomb using the OTLP exporter.
+
+First you need to edit [app.py](./app.app.py) to set your Honeycomb API key and dataset.
+
+Then run the web app.
+```
+python app.py
+```
+
+Finally, open `http://localhost:8080` to generate some trace data that will be visble in the [Honeycomb UI](http://ui.honeycomb.io).

--- a/python-otlp/app.py
+++ b/python-otlp/app.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
 otlp_exporter = OTLPSpanExporter(
 	endpoint="api.honeycomb.io:443",
 	credentials=ssl_channel_credentials(),
-	headers=(("x-honeycomb-team", ""),("x-honeycomb-dataset","test-otlp"))
+	headers=(("x-honeycomb-team", ""),("x-honeycomb-dataset",""))
 )
 
 trace.set_tracer_provider(TracerProvider(resource=Resource({"service.name": "python-otlp", "service.version":"0.1"})))


### PR DESCRIPTION
This PR tidies up the OTLP examples by doing the following:
- Add READMEs with instruction on how to run the example
- Remove default API key / dataset where set
- Ensure endpoints are consistent (eg `http://localhost:<port>/`)
- Add missing .gitignore's for java examples