### PR TITLE
Update dotnet-otlp example

### DIFF
--- a/dotnet-otlp/.editorconfig
+++ b/dotnet-otlp/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/dotnet-otlp/Startup.cs
+++ b/dotnet-otlp/Startup.cs
@@ -1,10 +1,12 @@
+using System;
+using Grpc.Core;
+using Grpc.Net.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -29,10 +31,12 @@ namespace dotnet_otlp
                         .AddHttpClientInstrumentation()
                         .AddOtlpExporter(otlpOptions =>
                         {
-                            otlpOptions.Endpoint = this.Configuration.GetValue<string>("Otlp:Endpoint");
-                            otlpOptions.Credentials = new Grpc.Core.SslCredentials();
+                            otlpOptions.Endpoint = new Uri(this.Configuration.GetValue<string>("Otlp:Endpoint"));
+                            otlpOptions.GrpcChannelOptions = new GrpcChannelOptions{
+                                Credentials = new SslCredentials()
+                            };
 
-                            var headers = new Grpc.Core.Metadata();
+                            var headers = new Metadata();
                             headers.Add("x-honeycomb-team", this.Configuration.GetValue<string>("Otlp:ApiKey"));
                             headers.Add("x-honeycomb-dataset", this.Configuration.GetValue<string>("Otlp:Dataset"));
                             otlpOptions.Headers = headers;

--- a/dotnet-otlp/dotnet-otlp.csproj
+++ b/dotnet-otlp/dotnet-otlp.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.0.0-rc1.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.0-rc1.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc1.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc1.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc1.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates the example to use the latest packages, including v1.0.1 of the base API. Also adds a `.editorconfig` to help manage code consistenty.