### PR TITLE
Fix no spans being generated or sent from node-otlp example

### DIFF
--- a/node-otlp/app.js
+++ b/node-otlp/app.js
@@ -1,11 +1,15 @@
 "use strict";
+const opentelemetry = require('@opentelemetry/api');
 
 const PORT = process.env.PORT || "8080";
 const express = require("express");
 const app = express();
 
 app.get("/", (req, res) => {
+  const span = opentelemetry.trace.getTracer('default').startSpan('world-greeter');
+  console.log("Saying hello to the world.")
   res.send("Hello world!");
+  span.end();
 });
 
 app.listen(parseInt(PORT, 10), () => {

--- a/node-otlp/package-lock.json
+++ b/node-otlp/package-lock.json
@@ -19,166 +19,111 @@
 			"integrity": "sha512-KczG0mtyH2UQLeFDYC+atGXfS/MfttynmHblJUsOnIgfI0Ohn0nJOgNjKwJlHk6/9Q61CBTxzSs/268TDaopVw=="
 		},
 		"@opentelemetry/api-metrics": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.17.0.tgz",
-			"integrity": "sha512-DVLuIl15/0tPuy9urqaTt3XnwQkfkohyM6m//EhfEYcMPBz86O9ZhMEBad29gCF7lda4ZiYFJsg/P2FsfHnHow==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.18.0.tgz",
+			"integrity": "sha512-5MGIP1Bb97yiRBLeHdfgDaMnoKE5+IOhUvE3FGRqiTMjun0cDt35gY4k5+w5pmqpcHFkt0/ih25YTKjF0tJLHg==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
-				}
+				"@opentelemetry/api": "^0.18.0"
 			}
 		},
 		"@opentelemetry/context-async-hooks": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.17.0.tgz",
-			"integrity": "sha512-RvbsTM3wm7N6XNTcjEVi4B5FiUlCENqyLIFe9VZp090jM8+KQ/KrBXotAJxLT9CcXGekRzbIKB3vutm2Eloiwg==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.18.0.tgz",
+			"integrity": "sha512-PD1aHXyniFtZIXbLuCr+KaZiufrGJPuEZ6eMZggQRi7+AC3alAfAVRz88sLmeR49pd7lRRFiKzymzVqJRMEmjw==",
 			"requires": {
-				"@opentelemetry/context-base": "^0.17.0"
+				"@opentelemetry/api": "^0.18.0"
 			}
 		},
-		"@opentelemetry/context-base": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.17.0.tgz",
-			"integrity": "sha512-q4Jy9JqTQh7/SE33YgKqcG5X2/JP9TbTpTmGoCBUYDKePK9E2uO40Rn4MjACqgnxu5sC61seG0P6xilvkpr9CQ=="
-		},
 		"@opentelemetry/core": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.17.0.tgz",
-			"integrity": "sha512-jRM0Ydcb98a1ejrShqJIhnc2qqPJI2SJfHDRsFeWCj/q6LIlPo7yRl9msIndUQjRTHHvLdIKBGclNvqoXRyXTA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
+			"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/context-base": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
 				"semver": "^7.1.3"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
-				}
 			}
 		},
 		"@opentelemetry/exporter-collector": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-collector/-/exporter-collector-0.17.0.tgz",
-			"integrity": "sha512-iXMgeumuUIK/qpbWdGhxYk20Crp5R3eNFiCCSrYqb+8fiMpRBCcg927414mqQrYChJ+UdENlzI5U2rTXNtjBog==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-collector/-/exporter-collector-0.18.0.tgz",
+			"integrity": "sha512-AMurbTrkhIDy+hCs7Iz3MdhRCUbhzQC3rUOIDwusnUDBOah7zD9OLm/6yS529jrYNfljzxHjeczV0oOsu9AcKQ==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/api-metrics": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/metrics": "^0.17.0",
-				"@opentelemetry/resources": "^0.17.0",
-				"@opentelemetry/tracing": "^0.17.0"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
-				}
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/api-metrics": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/metrics": "^0.18.0",
+				"@opentelemetry/resources": "^0.18.0",
+				"@opentelemetry/tracing": "^0.18.0"
 			}
 		},
 		"@opentelemetry/exporter-collector-grpc": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-collector-grpc/-/exporter-collector-grpc-0.17.0.tgz",
-			"integrity": "sha512-kDPUca6Xfmmk4UT0AN1Tj4x9stB4P/8imhuvZp2K06GGgxU6mjjl35WrZGrZ1HZN8MMg/U8UUVUrF8hbjjjTYA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-collector-grpc/-/exporter-collector-grpc-0.18.0.tgz",
+			"integrity": "sha512-fmZdlt+Y7nHb9VhfgAT2/+4sVGXIo6dNoAVTqE2orWmpI7bzzFYydmSTOM43XMByEjqJrONHV8l8NtCWHWvc3w==",
 			"requires": {
 				"@grpc/proto-loader": "^0.5.4",
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/exporter-collector": "^0.17.0",
-				"@opentelemetry/metrics": "^0.17.0",
-				"@opentelemetry/resources": "^0.17.0",
-				"@opentelemetry/tracing": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/exporter-collector": "^0.18.0",
+				"@opentelemetry/metrics": "^0.18.0",
+				"@opentelemetry/resources": "^0.18.0",
+				"@opentelemetry/tracing": "^0.18.0",
 				"grpc": "^1.24.2"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
-				}
 			}
 		},
 		"@opentelemetry/instrumentation": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.17.0.tgz",
-			"integrity": "sha512-w4L65/A67vUxjAVk8SV4YN7+XCeqcfk5bLEatzli2sFvOWfN+O70FxTQjA9OZ8prE+6TZqboULBJVafz8Zxunw==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.18.0.tgz",
+			"integrity": "sha512-YFrCnSWS9jJLChg5I8g7EuvpWqPZGa2EXyO8KwRJApuLPCqJSBkcymYieedWNupS0FAXntocpIb/b0SEVaZbEg==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/api-metrics": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/api-metrics": "^0.18.0",
 				"require-in-the-middle": "^5.0.3",
 				"semver": "^7.3.2",
 				"shimmer": "^1.2.1"
 			},
 			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
+				"@opentelemetry/api-metrics": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.18.0.tgz",
+					"integrity": "sha512-5MGIP1Bb97yiRBLeHdfgDaMnoKE5+IOhUvE3FGRqiTMjun0cDt35gY4k5+w5pmqpcHFkt0/ih25YTKjF0tJLHg==",
 					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
+						"@opentelemetry/api": "^0.18.0"
 					}
 				}
 			}
 		},
 		"@opentelemetry/metrics": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.17.0.tgz",
-			"integrity": "sha512-Fa7ClnXSsq1xzz09mf4uryR3Hbq5g5/dz1rbbTIuwXOqewMgbmbIpRzvh/gsucDD5l8Nx0M6aKOdinh+8QALkQ==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.18.0.tgz",
+			"integrity": "sha512-BH1P97bY6ZHBPNlW/0gV+Bc384Gqpu0KOdKWy2ZcntxGemhZ+byguL1AlqqS5ip+AaoCvgAmaY7JzuXq7YKo4A==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/api-metrics": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/resources": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/api-metrics": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/resources": "^0.18.0",
 				"lodash.merge": "^4.6.2"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
-				}
 			}
 		},
 		"@opentelemetry/node": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.17.0.tgz",
-			"integrity": "sha512-ED6Js2HNvsbekT43v7YE2cy8o1j5tbrWGIS48PiJj43l8XEFjrMWF9pezM7bGThno/f0L2vNuuYmc0B0/8QyMw==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.18.0.tgz",
+			"integrity": "sha512-KjN6O+BvNmBwjQHKpcIRyxebrRuEMUzyS4Y13ZMH684fBMwRTju45aDz7ILCFndGECvbtl8nDY0US7+HCimpXw==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/context-async-hooks": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/tracing": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/context-async-hooks": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/tracing": "^0.18.0",
 				"semver": "^7.1.3"
 			},
 			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
+				"@opentelemetry/core": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
+					"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
 					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
+						"@opentelemetry/api": "^0.18.0",
+						"semver": "^7.1.3"
 					}
 				}
 			}
@@ -219,115 +164,103 @@
 			}
 		},
 		"@opentelemetry/plugin-grpc": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/plugin-grpc/-/plugin-grpc-0.17.0.tgz",
-			"integrity": "sha512-lnDg1jBEuJlP5rCbw9afmqoAWjH+eRtLEjxPiWtlvfWOWcHCenVLhcw3tc7J35nz25x0lDGU59JMKuF0Ro8odQ==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/plugin-grpc/-/plugin-grpc-0.18.0.tgz",
+			"integrity": "sha512-0RBstDVLSa2kr3KDxRHmbtX6oNGGAiascfoF3iQEBd7/Tca0+RSCowQEv6SIBGcNOTajUIyX9twdDAcOBABMKA==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/semantic-conventions": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/semantic-conventions": "^0.18.0",
 				"shimmer": "^1.2.1"
 			},
 			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
+				"@opentelemetry/core": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
+					"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
 					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
+						"@opentelemetry/api": "^0.18.0",
+						"semver": "^7.1.3"
 					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.0.tgz",
+					"integrity": "sha512-02Wi/zFq+RWfY4llRicMashGhyZvUtMfXu9UlfXMJiDbGOgkdua4AeOCv9lDqv1GIz11xr5qS4tFjLp7WnlU+Q=="
 				}
 			}
 		},
 		"@opentelemetry/plugin-http": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/plugin-http/-/plugin-http-0.17.0.tgz",
-			"integrity": "sha512-DAsfns6xqqYnSxCX1usZ1QcpwKn03uuRloUQSNsrHy+3b6t+smiQlNjzAQAv3RBwu5GS03KlW3cLT6KYZ2khig==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/plugin-http/-/plugin-http-0.18.0.tgz",
+			"integrity": "sha512-+g4H+XKlDAAkNGHQcO2BJ25UtfdYO9te8xq/vILUDYKXXejcsrEjLwLe6xgSX6n936QyJjXi3sJmblBMHVx9ug==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/semantic-conventions": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/semantic-conventions": "^0.18.0",
 				"semver": "^7.1.3",
 				"shimmer": "^1.2.1"
 			},
 			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
+				"@opentelemetry/core": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
+					"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
 					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
+						"@opentelemetry/api": "^0.18.0",
+						"semver": "^7.1.3"
 					}
-				}
-			}
-		},
-		"@opentelemetry/plugin-https": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/plugin-https/-/plugin-https-0.17.0.tgz",
-			"integrity": "sha512-vNo0DWdLDFIl/T7fc2Q2lZ+lRc756Rl37fvu8iU8PQJOX11J1a4NMbUtXgDWepFFSFMrBVBTInSoqVhwo0kJkw==",
-			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/plugin-http": "^0.17.0",
-				"@opentelemetry/semantic-conventions": "^0.17.0",
-				"semver": "^7.1.3",
-				"shimmer": "^1.2.1"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.0.tgz",
+					"integrity": "sha512-02Wi/zFq+RWfY4llRicMashGhyZvUtMfXu9UlfXMJiDbGOgkdua4AeOCv9lDqv1GIz11xr5qS4tFjLp7WnlU+Q=="
 				}
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.17.0.tgz",
-			"integrity": "sha512-0f+RryxBh+m+8zrZ1x36CihK21KME/1pIFcPCH9095hDx9yHiAv1h3AGrR/knWpgA5j84Icr5ymlALarmpWSbg==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.0.tgz",
+			"integrity": "sha512-Mko4HpoI5cCYplhSyiCuMFi0QEG1Nw/YwHFyAK+A67r+sgmo1wVpM6Pengb+XlxJrrO8WgmLsDS3RHqoMWhWNQ==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0"
-			},
-			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
-					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
-					}
-				}
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0"
 			}
 		},
-		"@opentelemetry/semantic-conventions": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.17.0.tgz",
-			"integrity": "sha512-WtFcpOv1IHaI0kT2BaZcA6/+fkx6pWyJspUKBljA3HeNDIQgYGB2n6nL/6eaZzWNDvDBHzFEzOKULDJdIwGRlQ=="
-		},
 		"@opentelemetry/tracing": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.17.0.tgz",
-			"integrity": "sha512-fnhG6PsDyxpssNGvxx90UNHlsBtPJM0Ouegq7xqQidC33JsQRCFGL0XFMoRltXbuOjT+uKnOti/0o+AxwLnuJA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.18.0.tgz",
+			"integrity": "sha512-k7UAebuHBLPafS8rnkpZqNuM8nfwOg6OCmppekCMxdQzkuZS1attgelqyEIlX6NYh46DndyZ7BxBkiXF4S0Xwg==",
 			"requires": {
-				"@opentelemetry/api": "^0.17.0",
-				"@opentelemetry/context-base": "^0.17.0",
-				"@opentelemetry/core": "^0.17.0",
-				"@opentelemetry/resources": "^0.17.0",
-				"@opentelemetry/semantic-conventions": "^0.17.0",
+				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/core": "^0.18.0",
+				"@opentelemetry/resources": "^0.18.0",
+				"@opentelemetry/semantic-conventions": "^0.18.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"dependencies": {
-				"@opentelemetry/api": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.17.0.tgz",
-					"integrity": "sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==",
+				"@opentelemetry/core": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
+					"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
 					"requires": {
-						"@opentelemetry/context-base": "^0.17.0"
+						"@opentelemetry/api": "^0.18.0",
+						"semver": "^7.1.3"
 					}
+				},
+				"@opentelemetry/resources": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.0.tgz",
+					"integrity": "sha512-Mko4HpoI5cCYplhSyiCuMFi0QEG1Nw/YwHFyAK+A67r+sgmo1wVpM6Pengb+XlxJrrO8WgmLsDS3RHqoMWhWNQ==",
+					"requires": {
+						"@opentelemetry/api": "^0.18.0",
+						"@opentelemetry/core": "^0.18.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.0.tgz",
+					"integrity": "sha512-02Wi/zFq+RWfY4llRicMashGhyZvUtMfXu9UlfXMJiDbGOgkdua4AeOCv9lDqv1GIz11xr5qS4tFjLp7WnlU+Q=="
 				}
 			}
 		},

--- a/node-otlp/package.json
+++ b/node-otlp/package.json
@@ -10,12 +10,13 @@
 	"license": "Apache-2.0",
 	"dependencies": {
 		"@opentelemetry/api": "^0.18.0",
-		"@opentelemetry/exporter-collector-grpc": "^0.17.0",
-		"@opentelemetry/instrumentation": "^0.17.0",
-		"@opentelemetry/node": "^0.17.0",
+		"@opentelemetry/exporter-collector-grpc": "^0.18.0",
+		"@opentelemetry/instrumentation": "^0.18.0",
+		"@opentelemetry/node": "^0.18.0",
 		"@opentelemetry/plugin-express": "^0.13.1",
-		"@opentelemetry/plugin-grpc": "^0.17.0",
-		"@opentelemetry/tracing": "^0.17.0",
+		"@opentelemetry/plugin-http": "^0.18.0",
+		"@opentelemetry/plugin-grpc": "^0.18.0",
+		"@opentelemetry/tracing": "^0.18.0",
 		"express": "^4.17.1"
 	}
 }


### PR DESCRIPTION
I had to add otel/plugin-http to see spans generated and sent from the example. I wasn't seeing anything from plugin-express. This also includes a custom "my business logic" span to show the difference between auto-instrumentations and app-specific events.

With this change, `curl localhost:8080` results in a trace that looks like:
![Screen Shot 2021-03-03 at 9 00 41 PM](https://user-images.githubusercontent.com/517302/109899255-9480af00-7c63-11eb-8cb5-5971978376e1.png)
